### PR TITLE
fix: 修复高刷新率下点击动画加速的问题

### DIFF
--- a/src/Web/index.html
+++ b/src/Web/index.html
@@ -26,10 +26,13 @@ class MouseSpark {
         this.trail = [];
         this.isDown = false;
         this.lastPos = null;
+        this.baseFrameMs = 1000 / 60;
+        this.maxDeltaMs = 100;
+        this.lastFrameTime = performance.now();
 
         this.initCanvas();
         this.bindEvents();
-        this.loop();
+        requestAnimationFrame((now) => this.loop(now));
     }
 
     initCanvas() {
@@ -111,14 +114,18 @@ class MouseSpark {
         }
     }
 
-    loop() {
+    loop(now) {
+        const deltaMs = Math.min(now - this.lastFrameTime, this.maxDeltaMs);
+        this.lastFrameTime = now;
+        const frameScale = deltaMs / this.baseFrameMs;
+
         if (this.waves.length > 0 || this.sparks.length > 0 || this.trail.length > 0) {
             this.ctx.clearRect(0, 0, this.c.width, this.c.height);
             this.ctx.globalCompositeOperation = "lighter";
 
             for (let i = this.trail.length - 1; i >= 0; i--) {
                 let t = this.trail[i];
-                t.life -= this.isDown ? 0.085 : 0.18;
+                t.life -= (this.isDown ? 0.085 : 0.18) * frameScale;
                 if (t.life <= 0) this.trail.splice(i, 1);
             }
 
@@ -138,7 +145,7 @@ class MouseSpark {
 
             for (let i = this.waves.length - 1; i >= 0; i--) {
                 let w = this.waves[i];
-                w.life++;
+                w.life += frameScale;
                 let progress = w.life / w.max;
                 let ease = 1 - Math.pow(1 - Math.min(progress, 1), 3);
                 w.r = 26 * this.scale * ease;
@@ -153,9 +160,9 @@ class MouseSpark {
                     this.ctx.shadowBlur = 0;
                 }
                 let r = w.ring;
-                r.life++;
+                r.life += frameScale;
                 let rProg = Math.min(r.life / r.maxLife, 1);
-                r.ang -= r.rs;
+                r.ang -= r.rs * frameScale;
                 r.segs.forEach(seg => {
                     let shrink = Math.max(0, 1 - rProg);
                     let len = seg.len * shrink;
@@ -174,10 +181,12 @@ class MouseSpark {
 
             for (let i = this.sparks.length - 1; i >= 0; i--) {
                 let s = this.sparks[i];
-                s.x += s.vx; s.y += s.vy;
-                s.vx *= s.f; s.vy *= s.f;
-                s.rot += s.rs;
-                s.a -= 0.032;
+                s.x += s.vx * frameScale;
+                s.y += s.vy * frameScale;
+                s.vx *= Math.pow(s.f, frameScale);
+                s.vy *= Math.pow(s.f, frameScale);
+                s.rot += s.rs * frameScale;
+                s.a -= 0.032 * frameScale;
                 if (s.a <= 0) { this.sparks.splice(i, 1); continue; }
                 this.ctx.save();
                 this.ctx.translate(s.x, s.y);
@@ -192,7 +201,7 @@ class MouseSpark {
             }
             this.ctx.globalCompositeOperation = "source-over";
         }
-        requestAnimationFrame(() => this.loop());
+        requestAnimationFrame((nextNow) => this.loop(nextNow));
     }
 }
 


### PR DESCRIPTION

  ## 说明

  修复了点击特效在高刷新率显示器（如 144Hz、240Hz）或不同刷新率环境下动画
  速度不一致的问题。

  ## 问题原因

  当前动画逻辑基于 `requestAnimationFrame` 的每帧固定步进推进，例如：

  - 波纹生命周期使用 `life++`
  - 粒子位移使用固定 `vx / vy`
  - 透明度衰减使用固定减量
  - 旋转与阻尼也按固定帧步进更新

  这会导致刷新率越高，单位时间内执行的帧数越多，动画整体播放速度越快。

  ## 修复方式

  将动画更新逻辑改为基于帧间隔的时间步进：

  - 引入 `delta time`
  - 使用 `frameScale = deltaMs / (1000 / 60)` 统一换算到 60 FPS 基准
  - 将 trail、wave、ring、spark 的生命周期、位移、旋转、透明度衰减改为按
  `frameScale` 推进
  - 将粒子阻尼从固定每帧乘法改为 `Math.pow(f, frameScale)`，保证不同刷新率
  下衰减曲线一致

  ## 效果

  修复后，点击动画在 60Hz、144Hz、240Hz 等不同刷新率下的播放速度保持一致，
  不再出现刷新率越高动画越快的问题。
