### PR TITLE
feat: Hidden the "BASpark Overlay" in task list

### DIFF
--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -17,7 +17,8 @@ namespace BASpark
         private const int GWL_EXSTYLE = -20;
         private const int WS_EX_TRANSPARENT = 0x00000020;
         private const int WS_EX_LAYERED = 0x00080000;
-
+        private const int WS_EX_TOOLWINDOW = 0x00000080; 
+        
         private IKeyboardMouseEvents? _globalHook;
         private IntPtr _hwnd;
 
@@ -40,7 +41,7 @@ namespace BASpark
             base.OnSourceInitialized(e);
             _hwnd = new WindowInteropHelper(this).Handle;
             int style = GetWindowLong(_hwnd, GWL_EXSTYLE);
-            SetWindowLong(_hwnd, GWL_EXSTYLE, style | WS_EX_TRANSPARENT | WS_EX_LAYERED);
+            SetWindowLong(_hwnd, GWL_EXSTYLE, style | WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_TOOLWINDOW);
 
             this.Left = SystemParameters.VirtualScreenLeft;
             this.Top = SystemParameters.VirtualScreenTop;


### PR DESCRIPTION
隐藏了任务列表中的"BASpark Overlay"，原有实现中，未隐藏此窗口，按下Alt + Tab后出现此窗口，影响美观，如果关闭此窗口则会出现除非重启软件否则都不会有鼠标特效的问题。如图
<img width="1523" height="426" alt="sor" src="https://github.com/user-attachments/assets/ea924208-c157-4bd9-895e-86635ce5c434" />
这次修改增加了隐藏任务的选项，Overlay不会再在任务列表中显示
<img width="1353" height="442" alt="promote" src="https://github.com/user-attachments/assets/70a51c6c-7728-48e7-95bd-1383e2a21ab6" />
