### PR TITLE
Fix: 修复在高 DPI (如2K分辨率)缩放下的鼠标特效偏移问题

### DIFF
--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -164,8 +164,7 @@ namespace BASpark
                     if (currentTicks - _lastClickTicks < ClickIntervalTicks) return;
                     _lastClickTicks = currentTicks;
 
-                    System.Windows.Point clientPoint = this.PointFromScreen(new System.Windows.Point(e.X, e.Y));
-                    _ = webView.CoreWebView2.ExecuteScriptAsync($"if(window.externalBoom) window.externalBoom({clientPoint.X}, {clientPoint.Y});");
+                    _ = webView.CoreWebView2.ExecuteScriptAsync($"if(window.externalBoom) window.externalBoom({e.X}, {e.Y});");
                 }
             };
 
@@ -178,16 +177,11 @@ namespace BASpark
                 if (currentTicks - _lastMoveTicks < _moveIntervalTicks) return;
                 _lastMoveTicks = currentTicks;
 
-                System.Windows.Point clientPoint = this.PointFromScreen(new System.Windows.Point(e.X, e.Y));
-                if (ConfigManager.EnableAlwaysTrailEffect)
-                {
-                    webView.CoreWebView2.ExecuteScriptAsync($"window.enableAlwaysTrailEffect = true;");
-                }
-                else
-                {
-                    webView.CoreWebView2.ExecuteScriptAsync($"window.enableAlwaysTrailEffect = false;");
-                }
-                _ = webView.CoreWebView2.ExecuteScriptAsync($"if(window.externalMove) window.externalMove({clientPoint.X}, {clientPoint.Y});");
+                string trailFlag = ConfigManager.EnableAlwaysTrailEffect ? "true" : "false";
+                _ = webView.CoreWebView2.ExecuteScriptAsync($@"
+                    window.enableAlwaysTrailEffect = {trailFlag};
+                    if(window.externalMove) window.externalMove({e.X}, {e.Y});
+            ");
             };
 
             _globalHook.MouseUpExt += (s, e) => {

--- a/src/Web/index.html
+++ b/src/Web/index.html
@@ -302,13 +302,26 @@ window.externalBoom = (x, y) => {
     const now = Date.now();
     if (x === lastBoomX && y === lastBoomY && (now - lastBoomTime) < 25) return;
     lastBoomX = x; lastBoomY = y; lastBoomTime = now;
-    window.dispatchEvent(new MouseEvent('mousedown', { clientX: x, clientY: y, bubbles: true }));
+    
+    const dpr = window.devicePixelRatio || 1;
+    window.dispatchEvent(new MouseEvent('mousedown', { 
+        clientX: x / dpr, 
+        clientY: y / dpr, 
+        bubbles: true 
+    }));
+    
 };
 
 window.externalMove = (x, y) => {
     if (x === lastMoveX && y === lastMoveY) return;
     lastMoveX = x; lastMoveY = y;
-    window.dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y, bubbles: true }));
+    
+    const dpr = window.devicePixelRatio || 1;
+    window.dispatchEvent(new MouseEvent('mousemove', { 
+        clientX: x / dpr, 
+        clientY: y / dpr, 
+        bubbles: true 
+    }));
 };
 
 window.externalUp = () => {


### PR DESCRIPTION
针对 v1.1 版本在 2K/4K 等高分屏（缩放 > 100%）环境下特效位置偏移的问题，提交了此修复方案喵：主要改动：C# 端：停止使用 PointFromScreen 逻辑坐标，直接向 Web 端传递原始物理坐标 (e.X, e.Y) 喵

Web 端：在 index.html 中引入 window.devicePixelRatio 修正，将接收到的坐标除以缩放倍率，实现像素级的精准对齐喵。性能优化：合并了 MouseMove 事件中的脚本调用，通过单次 ExecuteScriptAsync 完成状态更新与坐标传递，降低了 IPC 通信开销

测试环境:
2560 x 1440
DPR: 1.25
OS: win 11

修复前后对比 :



https://github.com/user-attachments/assets/f9a3414e-fcd8-4c7a-a713-50e57b0a1a25







https://github.com/user-attachments/assets/4450b118-9e3d-4ed6-9096-bbc11f158d62



