### PR TITLE
fix: 修复多显示器凸出区域点击特效消失问题

### DIFF
--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 using Gma.System.MouseKeyHook;
+using Microsoft.Win32;
 
 namespace BASpark
 {
@@ -13,6 +14,10 @@ namespace BASpark
         static extern int GetWindowLong(IntPtr hWnd, int nIndex);
         [DllImport("user32.dll")]
         static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+        [DllImport("user32.dll")]
+        static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+        [DllImport("user32.dll")]
+        static extern int GetSystemMetrics(int nIndex);
 
         // 新增：引入获取光标信息的 API
         [DllImport("user32.dll")]
@@ -38,11 +43,21 @@ namespace BASpark
         private const int WS_EX_TRANSPARENT = 0x00000020;
         private const int WS_EX_LAYERED = 0x00080000;
         private const int WS_EX_TOOLWINDOW = 0x00000080; 
-        
+
         private const Int32 CURSOR_SHOWING = 0x00000001; // 新增：光标可见状态码
+        private const int SM_XVIRTUALSCREEN = 76;
+        private const int SM_YVIRTUALSCREEN = 77;
+        private const int SM_CXVIRTUALSCREEN = 78;
+        private const int SM_CYVIRTUALSCREEN = 79;
+        private const uint SWP_NOZORDER = 0x0004;
+        private const uint SWP_NOACTIVATE = 0x0010;
 
         private IKeyboardMouseEvents? _globalHook;
         private IntPtr _hwnd;
+        private int _virtualScreenLeft;
+        private int _virtualScreenTop;
+        private int _virtualScreenWidth;
+        private int _virtualScreenHeight;
 
         private long _lastMoveTicks = 0;
         private long _lastClickTicks = 0;
@@ -65,11 +80,8 @@ namespace BASpark
             int style = GetWindowLong(_hwnd, GWL_EXSTYLE);
             SetWindowLong(_hwnd, GWL_EXSTYLE, style | WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_TOOLWINDOW);
 
-            this.Left = SystemParameters.VirtualScreenLeft;
-            this.Top = SystemParameters.VirtualScreenTop;
-            this.Width = SystemParameters.VirtualScreenWidth;
-            this.Height = SystemParameters.VirtualScreenHeight;
-
+            UpdateOverlayBounds();
+            SystemEvents.DisplaySettingsChanged += HandleDisplaySettingsChanged;
             SetupGlobalHooks();
         }
 
@@ -146,6 +158,55 @@ namespace BASpark
             return true;
         }
 
+        private void HandleDisplaySettingsChanged(object? sender, EventArgs e)
+        {
+            Dispatcher.BeginInvoke(UpdateOverlayBounds);
+        }
+
+        private void UpdateOverlayBounds()
+        {
+            _virtualScreenLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
+            _virtualScreenTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
+            _virtualScreenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+            _virtualScreenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+            if (_hwnd == IntPtr.Zero || _virtualScreenWidth <= 0 || _virtualScreenHeight <= 0)
+            {
+                return;
+            }
+
+            SetWindowPos(
+                _hwnd,
+                IntPtr.Zero,
+                _virtualScreenLeft,
+                _virtualScreenTop,
+                _virtualScreenWidth,
+                _virtualScreenHeight,
+                SWP_NOZORDER | SWP_NOACTIVATE);
+        }
+
+        private bool TryConvertScreenToOverlayPoint(int screenX, int screenY, out System.Windows.Point clientPoint)
+        {
+            clientPoint = default;
+
+            double viewportWidth = webView.ActualWidth > 0 ? webView.ActualWidth : ActualWidth;
+            double viewportHeight = webView.ActualHeight > 0 ? webView.ActualHeight : ActualHeight;
+            if (_virtualScreenWidth <= 0 || _virtualScreenHeight <= 0 || viewportWidth <= 0 || viewportHeight <= 0)
+            {
+                return false;
+            }
+
+            double normalizedX = (screenX - _virtualScreenLeft) / (double)_virtualScreenWidth;
+            double normalizedY = (screenY - _virtualScreenTop) / (double)_virtualScreenHeight;
+            double maxX = Math.Max(0, viewportWidth - 1);
+            double maxY = Math.Max(0, viewportHeight - 1);
+
+            clientPoint = new System.Windows.Point(
+                Math.Clamp(normalizedX * viewportWidth, 0, maxX),
+                Math.Clamp(normalizedY * viewportHeight, 0, maxY));
+            return true;
+        }
+
         private void SetupGlobalHooks()
         {
             _globalHook = Hook.GlobalEvents();
@@ -164,7 +225,7 @@ namespace BASpark
                     if (currentTicks - _lastClickTicks < ClickIntervalTicks) return;
                     _lastClickTicks = currentTicks;
 
-                    System.Windows.Point clientPoint = this.PointFromScreen(new System.Windows.Point(e.X, e.Y));
+                    if (!TryConvertScreenToOverlayPoint(e.X, e.Y, out System.Windows.Point clientPoint)) return;
                     _ = webView.CoreWebView2.ExecuteScriptAsync($"if(window.externalBoom) window.externalBoom({clientPoint.X}, {clientPoint.Y});");
                 }
             };
@@ -178,7 +239,7 @@ namespace BASpark
                 if (currentTicks - _lastMoveTicks < _moveIntervalTicks) return;
                 _lastMoveTicks = currentTicks;
 
-                System.Windows.Point clientPoint = this.PointFromScreen(new System.Windows.Point(e.X, e.Y));
+                if (!TryConvertScreenToOverlayPoint(e.X, e.Y, out System.Windows.Point clientPoint)) return;
                 if (ConfigManager.EnableAlwaysTrailEffect)
                 {
                     webView.CoreWebView2.ExecuteScriptAsync($"window.enableAlwaysTrailEffect = true;");
@@ -198,6 +259,7 @@ namespace BASpark
 
         protected override void OnClosed(EventArgs e)
         {
+            SystemEvents.DisplaySettingsChanged -= HandleDisplaySettingsChanged;
             _globalHook?.Dispose();
             ConfigManager.Save("TotalClicks", ConfigManager.TotalClicks);
             base.OnClosed(e);


### PR DESCRIPTION
## 问题

  在双屏扩展模式下，当副屏的最低边缘低于主屏最低边缘时，副屏下方“凸出”区域点击不会触发特效。

  已知表现：

  - 副屏下边缘低于主屏下边缘时，副屏下方凸出区域点击无特效
  - 主屏下边缘低于副屏下边缘时正常
  - 副屏上边缘高于主屏上边缘时大多正常，但存在偶发失效

  ## 原因

  现有实现将全局鼠标坐标直接通过 WPF `PointFromScreen` 转成覆盖层内坐标，再传给 WebView。

  在多显示器扩展排列存在上下凸出区域时，这种坐标换算依赖 WPF 的局部屏幕映射，容易在虚拟桌面边界附近出现偏差，导致传入
  WebView 的坐标落到画布可视区域之外，因此点击后没有任何特效。

  ## 修复内容

  - 改为基于 Win32 虚拟桌面边界统一计算覆盖层坐标
  - 使用 `GetSystemMetrics(SM_XVIRTUALSCREEN/SM_YVIRTUALSCREEN/SM_CXVIRTUALSCREEN/SM_CYVIRTUALSCREEN)` 获取虚拟桌面原始边界
  - 将全局鼠标坐标先归一化到整个虚拟桌面，再映射到当前 WebView 视口
  - 在显示设置变化时刷新覆盖层窗口边界，避免运行中调整显示器排列后坐标失准

  ## 影响范围

  本次修改只调整了覆盖层的屏幕坐标换算方式，不改变原有特效逻辑与配置行为，目的是修复多屏凸出区域的命中问题，同时避免引入对单屏和常规双屏布局的回归。理论对多屏都有效，但本人只有双屏 因此只在双屏环境下简单的测试通过喵。

 （老农录屏法（笑

  ## 演示

---
修复前：

https://github.com/user-attachments/assets/9bb2d99b-ad4a-4a6d-a942-a18d37539342

---
修复后：

https://github.com/user-attachments/assets/9caf6f0f-dbf5-423f-8260-bc545fc3bce5

