### PR TITLE
优化触屏模式下的点击特效显示

### DIFF
--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -61,9 +61,15 @@ namespace BASpark
 
         private long _lastMoveTicks = 0;
         private long _lastClickTicks = 0;
+        private bool _isPrimaryPointerDown = false;
+        private bool _isTouchLikeInput = false;
+        private string? _lastReportedInputMode;
+        private bool? _lastReportedAlwaysTrail;
 
         private long _moveIntervalTicks = 250000;
         private const long ClickIntervalTicks = 300000;
+        private const string InputModeMouse = "mouse";
+        private const string InputModeTouch = "touch";
 
         public MainWindow()
         {
@@ -135,8 +141,11 @@ namespace BASpark
                     string htmlContent = reader.ReadToEnd();
                     webView.CoreWebView2.NavigateToString(htmlContent);
                     webView.CoreWebView2.NavigationCompleted += (s, e) => {
+                        _lastReportedInputMode = null;
+                        _lastReportedAlwaysTrail = null;
                         UpdateColor(ConfigManager.ParticleColor);
                         UpdateEffectSettings(ConfigManager.EffectScale, ConfigManager.EffectOpacity, ConfigManager.EffectSpeed);
+                        SyncInputContext(InputModeMouse);
                     };
                 }
             }
@@ -156,6 +165,43 @@ namespace BASpark
                 return (pci.flags & CURSOR_SHOWING) != 0;
             }
             return true;
+        }
+
+        private string BuildInputContextScript(string inputMode)
+        {
+            bool alwaysTrailEnabled = ConfigManager.EnableAlwaysTrailEffect;
+            if (_lastReportedInputMode == inputMode && _lastReportedAlwaysTrail == alwaysTrailEnabled)
+            {
+                return string.Empty;
+            }
+
+            _lastReportedInputMode = inputMode;
+            _lastReportedAlwaysTrail = alwaysTrailEnabled;
+            string alwaysTrailLiteral = alwaysTrailEnabled ? "true" : "false";
+            return $"if(window.setInputContext) window.setInputContext('{inputMode}', {alwaysTrailLiteral});";
+        }
+
+        private void SyncInputContext(string inputMode)
+        {
+            if (webView?.CoreWebView2 == null) return;
+
+            string script = BuildInputContextScript(inputMode);
+            if (string.IsNullOrEmpty(script)) return;
+
+            _ = webView.CoreWebView2.ExecuteScriptAsync(script);
+        }
+
+        private void ExecuteWithInputContext(string inputMode, string actionScript)
+        {
+            if (webView?.CoreWebView2 == null) return;
+
+            string contextScript = BuildInputContextScript(inputMode);
+            _ = webView.CoreWebView2.ExecuteScriptAsync(contextScript + actionScript);
+        }
+
+        private static string FormatCoordinate(double value)
+        {
+            return value.ToString("F3", CultureInfo.InvariantCulture);
         }
 
         private void HandleDisplaySettingsChanged(object? sender, EventArgs e)
@@ -214,46 +260,53 @@ namespace BASpark
             _globalHook.MouseDownExt += (s, e) => {
                 if (!ConfigManager.IsEffectEnabled || webView?.CoreWebView2 == null) return;
 
-                // 光标被隐藏则拦截点击特效
-                if (!IsCursorVisible()) return;
+                if (e.Button != System.Windows.Forms.MouseButtons.Left) return;
 
-                if (e.Button == System.Windows.Forms.MouseButtons.Left)
-                {
-                    ConfigManager.TotalClicks++; 
+                _isPrimaryPointerDown = true;
+                _isTouchLikeInput = !IsCursorVisible();
 
-                    long currentTicks = DateTime.Now.Ticks;
-                    if (currentTicks - _lastClickTicks < ClickIntervalTicks) return;
-                    _lastClickTicks = currentTicks;
+                string inputMode = _isTouchLikeInput ? InputModeTouch : InputModeMouse;
+                SyncInputContext(inputMode);
 
-                    if (!TryConvertScreenToOverlayPoint(e.X, e.Y, out System.Windows.Point clientPoint)) return;
-                    _ = webView.CoreWebView2.ExecuteScriptAsync($"if(window.externalBoom) window.externalBoom({clientPoint.X}, {clientPoint.Y});");
-                }
+                ConfigManager.TotalClicks++;
+
+                long currentTicks = DateTime.Now.Ticks;
+                if (currentTicks - _lastClickTicks < ClickIntervalTicks) return;
+                _lastClickTicks = currentTicks;
+
+                if (!TryConvertScreenToOverlayPoint(e.X, e.Y, out System.Windows.Point clientPoint)) return;
+                string x = FormatCoordinate(clientPoint.X);
+                string y = FormatCoordinate(clientPoint.Y);
+                ExecuteWithInputContext(inputMode, $"if(window.externalBoom) window.externalBoom({x}, {y});");
             };
 
             _globalHook.MouseMoveExt += (s, e) => {
                 if (!ConfigManager.IsEffectEnabled || webView?.CoreWebView2 == null) return;
 
-                if (!IsCursorVisible()) return;
+                bool cursorVisible = IsCursorVisible();
+                if (!cursorVisible && !_isPrimaryPointerDown) return;
+
+                string inputMode = (_isTouchLikeInput || !cursorVisible) ? InputModeTouch : InputModeMouse;
+                SyncInputContext(inputMode);
 
                 long currentTicks = DateTime.Now.Ticks;
                 if (currentTicks - _lastMoveTicks < _moveIntervalTicks) return;
                 _lastMoveTicks = currentTicks;
 
                 if (!TryConvertScreenToOverlayPoint(e.X, e.Y, out System.Windows.Point clientPoint)) return;
-                if (ConfigManager.EnableAlwaysTrailEffect)
-                {
-                    webView.CoreWebView2.ExecuteScriptAsync($"window.enableAlwaysTrailEffect = true;");
-                }
-                else
-                {
-                    webView.CoreWebView2.ExecuteScriptAsync($"window.enableAlwaysTrailEffect = false;");
-                }
-                _ = webView.CoreWebView2.ExecuteScriptAsync($"if(window.externalMove) window.externalMove({clientPoint.X}, {clientPoint.Y});");
+                string x = FormatCoordinate(clientPoint.X);
+                string y = FormatCoordinate(clientPoint.Y);
+                ExecuteWithInputContext(inputMode, $"if(window.externalMove) window.externalMove({x}, {y});");
             };
 
             _globalHook.MouseUpExt += (s, e) => {
                 if (!ConfigManager.IsEffectEnabled || webView?.CoreWebView2 == null) return;
-                _ = webView.CoreWebView2.ExecuteScriptAsync($"if(window.externalUp) window.externalUp();");
+                if (e.Button != System.Windows.Forms.MouseButtons.Left) return;
+
+                string inputMode = _isTouchLikeInput ? InputModeTouch : InputModeMouse;
+                ExecuteWithInputContext(inputMode, "if(window.externalUp) window.externalUp();");
+                _isPrimaryPointerDown = false;
+                _isTouchLikeInput = false;
             };
         }
 

--- a/src/Web/index.html
+++ b/src/Web/index.html
@@ -68,7 +68,7 @@ class MouseSpark {
         });
 
         window.addEventListener("mousemove", e => {
-            if (!this.isDown && !window.enableAlwaysTrailEffect) return;
+            if (!this.isDown && !window.effectiveAlwaysTrail) return;
             const p = getPos(e);
             if (!this.lastPos) this.lastPos = p;
             
@@ -171,7 +171,7 @@ class MouseSpark {
 
             for (let i = this.trail.length - 1; i >= 0; i--) {
                 let t = this.trail[i];
-                if (window.enableAlwaysTrailEffect) {
+                if (window.effectiveAlwaysTrail) {
                     t.life -= 0.085 * frameScale;
                 } else {
                     t.life -= (this.isDown ? 0.085 : 0.18) * frameScale;
@@ -296,7 +296,17 @@ let lastBoomX = -1, lastBoomY = -1;
 let lastBoomTime = 0; 
 let lastMoveX = -1, lastMoveY = -1;
 
+window.currentInputMode = "mouse";
 window.enableAlwaysTrailEffect = false;
+window.effectiveAlwaysTrail = false;
+
+window.setInputContext = (mode, alwaysTrailEnabled) => {
+    window.currentInputMode = mode === "touch" ? "touch" : "mouse";
+    window.enableAlwaysTrailEffect = Boolean(alwaysTrailEnabled);
+    window.effectiveAlwaysTrail = window.currentInputMode === "mouse" && window.enableAlwaysTrailEffect;
+};
+
+window.setInputContext("mouse", false);
 
 window.externalBoom = (x, y) => {
     const now = Date.now();


### PR DESCRIPTION
**描述**
这个 PR 主要修复了一个触屏场景下的体验问题。

之前程序会把“鼠标指针被系统隐藏”当成无效输入，所以在 Windows 触屏模式下，用户点击屏幕时，点击特效有时不会显示。实际上这类操作依然是有效输入，只是系统不再显示鼠标指针了。

这次改动后：
- 触屏点击时也会正常显示点击特效
- 触屏按住拖动时也能正常显示拖尾
- 触屏模式下不会出现类似鼠标悬停时的常驻拖尾，整体表现会更自然
- 鼠标模式下原有行为保持不变

实现上做了两件事：
- 程序端不再因为指针隐藏就直接忽略输入，而是把这类情况按“触屏输入”处理
- 特效页面增加了输入模式判断，区分鼠标和触屏两种表现方式

**已验证**
- 项目可以正常构建通过
- 鼠标点击和鼠标拖动逻辑未被破坏
- 触屏模式下点击和拖动的特效逻辑已补齐