### PR TITLE
解决多显示器下的特效偏移问题，以及在分辨率大于等于2k的或非标屏幕仍可能出现的偏移问题

### DIFF
--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -84,7 +84,7 @@ namespace BASpark
         private const int GWL_EXSTYLE = -20;
         private const int WS_EX_TRANSPARENT = 0x00000020;
         private const int WS_EX_LAYERED = 0x00080000;
-        private const int WS_EX_TOOLWINDOW = 0x00000080; 
+        private const int WS_EX_TOOLWINDOW = 0x00000080;
 
         private const Int32 CURSOR_SHOWING = 0x00000001; // 光标可见状态码
         private const int SM_XVIRTUALSCREEN = 76;
@@ -93,7 +93,7 @@ namespace BASpark
         private const int SM_CYVIRTUALSCREEN = 79;
         private const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
         private const int FullscreenTolerance = 2;
-        
+
         private static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
         private const uint SWP_NOSIZE = 0x0001;
         private const uint SWP_NOMOVE = 0x0002;
@@ -170,7 +170,7 @@ namespace BASpark
         {
             if (_hwnd == IntPtr.Zero) return;
 
-            SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0, 
+            SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
         }
 
@@ -211,19 +211,19 @@ namespace BASpark
 
         private async System.Threading.Tasks.Task InitWebView()
         {
-            try 
+            try
             {
                 var options = new Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions(
                     "--disable-background-timer-throttling --disable-features=CalculateNativeWinOcclusion --enable-begin-frame-scheduling"
                 );
 
                 string userDataFolder = System.IO.Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), 
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                     "BASpark_WebView2");
 
                 var env = await Microsoft.Web.WebView2.Core.CoreWebView2Environment.CreateAsync(null, userDataFolder, options);
                 await webView.EnsureCoreWebView2Async(env);
-                
+
                 webView.CoreWebView2.Settings.IsZoomControlEnabled = false;
                 webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
                 webView.CoreWebView2.Settings.IsStatusBarEnabled = false;
@@ -234,7 +234,8 @@ namespace BASpark
                     using var reader = new System.IO.StreamReader(streamInfo.Stream);
                     string htmlContent = reader.ReadToEnd();
                     webView.CoreWebView2.NavigateToString(htmlContent);
-                    webView.CoreWebView2.NavigationCompleted += (s, e) => {
+                    webView.CoreWebView2.NavigationCompleted += (s, e) =>
+                    {
                         _lastReportedInputMode = null;
                         _lastReportedAlwaysTrail = null;
                         UpdateColor(ConfigManager.ParticleColor);
@@ -535,33 +536,41 @@ namespace BASpark
                 SWP_NOACTIVATE);
         }
 
-        private bool TryConvertScreenToOverlayPoint(int screenX, int screenY, out System.Windows.Point clientPoint)
+        private bool TryConvertScreenToOverlayPoint(int screenX, int screenY, out System.Windows.Point percentPoint)
         {
-            clientPoint = default;
+            percentPoint = default;
+            try
+            {
+                // 1. 获取窗口绝对的物理边界
+                if (!GetWindowRect(_hwnd, out RECT rect)) return false;
 
-            double viewportWidth = webView.ActualWidth > 0 ? webView.ActualWidth : ActualWidth;
-            double viewportHeight = webView.ActualHeight > 0 ? webView.ActualHeight : ActualHeight;
-            if (_virtualScreenWidth <= 0 || _virtualScreenHeight <= 0 || viewportWidth <= 0 || viewportHeight <= 0)
+                double physWidth = rect.Right - rect.Left;
+                double physHeight = rect.Bottom - rect.Top;
+                if (physWidth <= 0 || physHeight <= 0) return false;
+
+                // 2. 计算出纯物理维度的百分比 (0.000 ~ 1.000)
+                double percentX = (screenX - rect.Left) / physWidth;
+                double percentY = (screenY - rect.Top) / physHeight;
+
+                // 3. 将百分比包装在 Point 里传给下面，彻底抛弃 viewportWidth
+                percentPoint = new System.Windows.Point(
+                    Math.Clamp(percentX, 0.0, 1.0),
+                    Math.Clamp(percentY, 0.0, 1.0)
+                );
+                return true;
+            }
+            catch
             {
                 return false;
             }
-
-            double normalizedX = (screenX - _virtualScreenLeft) / (double)_virtualScreenWidth;
-            double normalizedY = (screenY - _virtualScreenTop) / (double)_virtualScreenHeight;
-            double maxX = Math.Max(0, viewportWidth - 1);
-            double maxY = Math.Max(0, viewportHeight - 1);
-
-            clientPoint = new System.Windows.Point(
-                Math.Clamp(normalizedX * viewportWidth, 0, maxX),
-                Math.Clamp(normalizedY * viewportHeight, 0, maxY));
-            return true;
         }
 
         private void SetupGlobalHooks()
         {
             _globalHook = Hook.GlobalEvents();
 
-            _globalHook.MouseDownExt += (s, e) => {
+            _globalHook.MouseDownExt += (s, e) =>
+            {
                 if (!CanRenderEffects()) return;
                 if (e.Button != System.Windows.Forms.MouseButtons.Left) return;
 
@@ -584,7 +593,8 @@ namespace BASpark
                 ExecuteWithInputContext(inputMode, $"if(window.externalBoom) window.externalBoom({x}, {y});");
             };
 
-            _globalHook.MouseMoveExt += (s, e) => {
+            _globalHook.MouseMoveExt += (s, e) =>
+            {
                 if (!CanRenderEffects()) return;
 
                 bool cursorVisible = IsCursorVisible();
@@ -603,7 +613,8 @@ namespace BASpark
                 ExecuteWithInputContext(inputMode, $"if(window.externalMove) window.externalMove({x}, {y});");
             };
 
-            _globalHook.MouseUpExt += (s, e) => {
+            _globalHook.MouseUpExt += (s, e) =>
+            {
                 if (!CanRenderEffects()) return;
                 if (e.Button != System.Windows.Forms.MouseButtons.Left) return;
 

--- a/src/Web/index.html
+++ b/src/Web/index.html
@@ -308,19 +308,27 @@ window.setInputContext = (mode, alwaysTrailEnabled) => {
 
 window.setInputContext("mouse", false);
 
-window.externalBoom = (x, y) => {
+// 核心修复：接收 C# 传来的物理百分比 (0.0 ~ 1.0)，由前端根据真实的画布宽度自行计算
+window.externalBoom = (percentX, percentY) => {
     const now = Date.now();
-    if (x === lastBoomX && y === lastBoomY && (now - lastBoomTime) < 25) return;
-    lastBoomX = x; lastBoomY = y; lastBoomTime = now;
-    window.dispatchEvent(new MouseEvent('mousedown', { clientX: x, clientY: y, bubbles: true }));
+    if (percentX === lastBoomX && percentY === lastBoomY && (now - lastBoomTime) < 25) return;
+    lastBoomX = percentX; lastBoomY = percentY; lastBoomTime = now;
+    
+    // 用百分比乘以 WebView 当前真实的内部宽度
+    let cx = percentX * window.innerWidth;
+    let cy = percentY * window.innerHeight;
+    window.dispatchEvent(new MouseEvent('mousedown', { clientX: cx, clientY: cy, bubbles: true }));
 };
 
-window.externalMove = (x, y) => {
-    if (x === lastMoveX && y === lastMoveY) return;
-    lastMoveX = x; lastMoveY = y;
-    window.dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y, bubbles: true }));
+window.externalMove = (percentX, percentY) => {
+    if (percentX === lastMoveX && percentY === lastMoveY) return;
+    lastMoveX = percentX; lastMoveY = percentY;
+    
+    // 用百分比乘以 WebView 当前真实的内部宽度
+    let cx = percentX * window.innerWidth;
+    let cy = percentY * window.innerHeight;
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: cx, clientY: cy, bubbles: true }));
 };
-
 window.externalUp = () => {
     window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
 };

--- a/src/Web/index.html
+++ b/src/Web/index.html
@@ -308,13 +308,13 @@ window.setInputContext = (mode, alwaysTrailEnabled) => {
 
 window.setInputContext("mouse", false);
 
-// 核心修复：接收 C# 传来的物理百分比 (0.0 ~ 1.0)，由前端根据真实的画布宽度自行计算
+// 接收 C# 传来的物理百分比 (0.0 ~ 1.0)，由前端根据真实的画布宽度自行计算
 window.externalBoom = (percentX, percentY) => {
     const now = Date.now();
     if (percentX === lastBoomX && percentY === lastBoomY && (now - lastBoomTime) < 25) return;
     lastBoomX = percentX; lastBoomY = percentY; lastBoomTime = now;
     
-    // 用百分比乘以 WebView 当前真实的内部宽度
+    // 百分比乘以 WebView 当前真实的内部宽度
     let cx = percentX * window.innerWidth;
     let cy = percentY * window.innerHeight;
     window.dispatchEvent(new MouseEvent('mousedown', { clientX: cx, clientY: cy, bubbles: true }));
@@ -324,7 +324,7 @@ window.externalMove = (percentX, percentY) => {
     if (percentX === lastMoveX && percentY === lastMoveY) return;
     lastMoveX = percentX; lastMoveY = percentY;
     
-    // 用百分比乘以 WebView 当前真实的内部宽度
+    // 方法与上述相同
     let cx = percentX * window.innerWidth;
     let cy = percentY * window.innerHeight;
     window.dispatchEvent(new MouseEvent('mousemove', { clientX: cx, clientY: cy, bubbles: true }));

--- a/src/app.manifest
+++ b/src/app.manifest
@@ -15,9 +15,11 @@
     </application>
   </compatibility>
 
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
-      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
-    </windowsSettings>
-  </application>
+<application xmlns="urn:schemas-microsoft-com:asm.v3">
+      <windowsSettings>
+        <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      </windowsSettings>
+    </application>
 </assembly>


### PR DESCRIPTION
# 解决多显示器下的特效偏移问题，以及在分辨率大于等于2k的或非标屏幕仍可能出现的偏移问题

## 问题

之前在 **#19** 里虽然试着修过偏移，但在我的屏幕组合（主屏 2.5K 150% 缩放 + 副屏 2K 100% 缩放）下，仍然会出现漂移问题。。

**原因：** C# 代码和网页前端对缩放的标准不一样，C# 先捕获鼠标位置，传给网页后，网页会按自己的缩放率算，会再缩放一次，导致特效偏移，而如果两个屏幕缩放比例不一样，网页端在计算宽度的时候会受到另一个屏幕的缩放影响，也会导致偏移。

## 解决方案

C# 不再传鼠标具体的“像素位置”，而是改传“**百分比**”：

1. **C#** ：它不再算鼠标在哪个像素，而是算鼠标在屏幕总宽度的百分之几（比如 65.4%）。
    
2. **网页前端**：拿到这个百分比，会在自己画布的 65.4% 位置形成特效。

## 改动

- **MainWindow.xaml.cs**：重写了坐标转换函数，现在只输出物理百分比。
    
- **index.html**：修改了接收接口，把百分比换算回网页自己的坐标。
    
- **app.manifest**：顺手补全了之前漏掉的 DPI 声明。