### PR TITLE
chore: 移除 MIT License 后面不准确的备注

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
             ---
             
             - **运行环境**：Windows 10/11 (x64) | .NET 8.0 Runtime
-            - **开源协议**：MIT License (完全免费，禁止商用)
+            - **开源协议**：MIT License
             - **问题反馈**：请提交 [Issues] 或联系作者。
 
             本次更新包含以下改动：


### PR DESCRIPTION
QWQ