### PR TITLE
fix：鼠标尾迹在转折处出现异常段轨迹的渲染

### DIFF
--- a/src/Web/index.html
+++ b/src/Web/index.html
@@ -192,30 +192,35 @@ class MouseSpark {
                 // this.ctx.stroke();
                 
 
-                // =============新增的屎===============
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.trail[0].x, this.trail[0].y);
-                for (let i = 1; i < this.trail.length; i++) {
-                    this.ctx.lineTo(this.trail[i].x, this.trail[i].y);
-                }
+                // 逐段渲染：每段的透明度基于数组索引位置，而非空间位置
+                // 防止当鼠标锐角转动时，尾迹变淡后突然出现的问题
                 this.ctx.lineWidth = 5.0;
-
-                const meteorHead = this.trail[this.trail.length - 1];
-                const meteorTail = this.trail[0];
-                const gradient = this.ctx.createLinearGradient(
-                    meteorHead.x, meteorHead.y,
-                    meteorTail.x, meteorTail.y
-                );
-                gradient.addColorStop(0, `rgba(${this.color}, 1)`);
-                gradient.addColorStop(1, `rgba(${this.color}, 0)`);
-
-                this.ctx.shadowColor = `rgba(${this.color}, 0.6)`; 
+                this.ctx.shadowColor = `rgba(${this.color}, 0.6)`;
                 this.ctx.shadowBlur = 3;
                 this.ctx.shadowOffsetX = 0;
                 this.ctx.shadowOffsetY = 0;
 
-                this.ctx.strokeStyle = gradient;
-                this.ctx.stroke();
+                const lastIdx = this.trail.length - 1;
+                for (let i = 0; i < lastIdx; i++) {
+                    const alphaStart = i / lastIdx;
+                    const alphaEnd = (i + 1) / lastIdx;
+                    const a0 = this.trail[i];
+                    const a1 = this.trail[i + 1];
+
+                    // 每段使用独立的两点渐变，只覆盖该段自身
+                    const segGrad = this.ctx.createLinearGradient(
+                        a0.x, a0.y, a1.x, a1.y
+                    );
+                    segGrad.addColorStop(0, `rgba(${this.color}, ${alphaStart})`);
+                    segGrad.addColorStop(1, `rgba(${this.color}, ${alphaEnd})`);
+
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(a0.x, a0.y);
+                    this.ctx.lineTo(a1.x, a1.y);
+                    this.ctx.strokeStyle = segGrad;
+                    this.ctx.stroke();
+                }
+
                 this.ctx.shadowColor = 'transparent';
 
             }


### PR DESCRIPTION
# fix：鼠标尾迹在转折处出现异常段轨迹的渲染 Bug
## 问题描述
在较低拖尾刷新率和动画播放速度下，当鼠标移动轨迹产生明显弯折或快速改变方向时，尾迹中会突然出现一段或多段不连贯的尾迹。~~其实正常速度应该也有只是看不出来~~
## 修复方案
将尾迹每段改为逐段独立渲染
## 效果如下
修复前:

https://github.com/user-attachments/assets/ffd7d62e-c2f9-45c7-9e6f-8c98ad5c1be2

修复后:

https://github.com/user-attachments/assets/fa430dee-e99c-4105-b876-edf2bc54e595

