### PR TITLE
 feat: 重构环境过滤系统，支持多配置组切换与桌面独立控制

### DIFF
--- a/src/BASpark.csproj
+++ b/src/BASpark.csproj
@@ -8,6 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+    <UseVisualBasic>true</UseVisualBasic>
     <ApplicationIcon>app.ico</ApplicationIcon>
 
     <Version>1.2.0</Version>

--- a/src/ConfigManager.cs
+++ b/src/ConfigManager.cs
@@ -12,6 +12,14 @@ namespace BASpark
         Whitelist
     }
 
+    public class FilterProfile
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string Name { get; set; } = "新配置组";
+        public ProcessFilterModeOption Mode { get; set; } = ProcessFilterModeOption.Blacklist;
+        public List<string> Processes { get; set; } = new List<string>();
+    }
+
     public static class ConfigManager
     {
         private const string RegPath = @"Software\BASpark";
@@ -32,9 +40,12 @@ namespace BASpark
         public static int TrailRefreshRate { get; set; } = 40;
         public static bool EnableEnvironmentFilter { get; set; } = false;
         public static bool HideInFullscreen { get; set; } = true;
-        public static ProcessFilterModeOption ProcessFilterMode { get; set; } = ProcessFilterModeOption.Disabled;
-        public static string ProcessFilterList { get; set; } = "";
+        public static bool ShowEffectOnDesktop { get; set; } = true;
+        public static string FilterProfiles { get; set; } = "";
+        public static string ActiveProfileId { get; set; } = "";
         public static bool IsTouchscreenMode { get; set; } = false;
+
+        private static List<FilterProfile> _profiles = new List<FilterProfile>();
 
         public static void Load()
         {
@@ -61,21 +72,71 @@ namespace BASpark
                         TrailRefreshRate = Math.Clamp(Convert.ToInt32(key.GetValue("TrailRefreshRate", 40)), 10, 240);
                         EnableEnvironmentFilter = Convert.ToBoolean(key.GetValue("EnableEnvironmentFilter", false));
                         HideInFullscreen = Convert.ToBoolean(key.GetValue("HideInFullscreen", true));
+                        ShowEffectOnDesktop = Convert.ToBoolean(key.GetValue("ShowEffectOnDesktop", true));
                         IsTouchscreenMode = Convert.ToBoolean(key.GetValue("IsTouchscreenMode", false));
 
-                        string processFilterModeRaw = key.GetValue("ProcessFilterMode", ProcessFilterModeOption.Disabled.ToString())?.ToString()
-                            ?? ProcessFilterModeOption.Disabled.ToString();
-                        if (!Enum.TryParse(processFilterModeRaw, true, out ProcessFilterModeOption processFilterMode))
+                        FilterProfiles = key.GetValue("FilterProfiles", "")?.ToString() ?? "";
+                        ActiveProfileId = key.GetValue("ActiveProfileId", "")?.ToString() ?? "";
+
+                        if (!string.IsNullOrEmpty(FilterProfiles))
                         {
-                            processFilterMode = ProcessFilterModeOption.Disabled;
+                            try
+                            {
+                                _profiles = System.Text.Json.JsonSerializer.Deserialize<List<FilterProfile>>(FilterProfiles) ?? new List<FilterProfile>();
+                            }
+                            catch { _profiles = new List<FilterProfile>(); }
                         }
 
-                        ProcessFilterMode = processFilterMode;
-                        ProcessFilterList = NormalizeProcessFilterList(key.GetValue("ProcessFilterList", "")?.ToString() ?? "");
+                        // 向后兼容处理
+                        if (_profiles.Count == 0)
+                        {
+                            string processFilterModeRaw = key.GetValue("ProcessFilterMode", "Disabled")?.ToString() ?? "Disabled";
+                            ProcessFilterModeOption oldMode;
+                            if (!Enum.TryParse(processFilterModeRaw, true, out oldMode))
+                            {
+                                oldMode = ProcessFilterModeOption.Disabled;
+                            }
+                            string oldListRaw = key.GetValue("ProcessFilterList", "")?.ToString() ?? "";
+                            var oldList = oldListRaw
+                                .Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                                .Select(s => s.ToLowerInvariant())
+                                .Distinct()
+                                .ToList();
+
+                            var defaultProfile = new FilterProfile
+                            {
+                                Name = "默认配置",
+                                Mode = oldMode == ProcessFilterModeOption.Disabled ? ProcessFilterModeOption.Blacklist : oldMode,
+                                Processes = oldList
+                            };
+                            _profiles.Add(defaultProfile);
+                            ActiveProfileId = defaultProfile.Id;
+                        }
+
+                        if (string.IsNullOrEmpty(ActiveProfileId) && _profiles.Count > 0)
+                        {
+                            ActiveProfileId = _profiles[0].Id;
+                        }
                     }
                 }
             }
             catch { }
+        }
+
+        public static List<FilterProfile> GetProfiles() => _profiles;
+
+        public static FilterProfile? GetActiveProfile()
+        {
+            return _profiles.FirstOrDefault(p => p.Id == ActiveProfileId) ?? _profiles.FirstOrDefault();
+        }
+
+        public static void SaveProfiles(List<FilterProfile> profiles, string activeId)
+        {
+            _profiles = profiles;
+            ActiveProfileId = activeId;
+            string json = System.Text.Json.JsonSerializer.Serialize(_profiles);
+            Save("FilterProfiles", json);
+            Save("ActiveProfileId", activeId);
         }
 
         public static void Save(string name, object value)
@@ -116,34 +177,12 @@ namespace BASpark
             catch { }
         }
 
-        public static string NormalizeProcessFilterList(string rawValue)
-        {
-            if (string.IsNullOrWhiteSpace(rawValue))
-            {
-                return string.Empty;
-            }
-
-            var normalizedLines = rawValue
-                .Replace("\r\n", "\n")
-                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(line => line.Trim().ToLowerInvariant())
-                .Where(line => !string.IsNullOrWhiteSpace(line))
-                .Distinct(StringComparer.OrdinalIgnoreCase);
-
-            return string.Join(Environment.NewLine, normalizedLines);
-        }
-
         public static IReadOnlySet<string> GetProcessFilterEntries()
         {
-            string normalized = NormalizeProcessFilterList(ProcessFilterList);
-            if (string.IsNullOrEmpty(normalized))
-            {
-                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            }
+            var profile = GetActiveProfile();
+            if (profile == null) return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            return normalized
-                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            return profile.Processes.ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
 
         public static void ResetAndClear()
@@ -152,7 +191,6 @@ namespace BASpark
             {
                 Registry.CurrentUser.DeleteSubKeyTree(RegPath, false);
 
-                // 适配 264100 版本之前的配置存储逻辑
                 string oldJson = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json");
                 if (System.IO.File.Exists(oldJson))
                 {
@@ -175,8 +213,10 @@ namespace BASpark
                 TrailRefreshRate = 40;
                 EnableEnvironmentFilter = false;
                 HideInFullscreen = true;
-                ProcessFilterMode = ProcessFilterModeOption.Disabled;
-                ProcessFilterList = "";
+                ShowEffectOnDesktop = true;
+                FilterProfiles = "";
+                ActiveProfileId = "";
+                _profiles.Clear();
                 IsTouchscreenMode = false;
             }
             catch { }

--- a/src/ControlPanelWindow.xaml
+++ b/src/ControlPanelWindow.xaml
@@ -313,40 +313,73 @@
                             <TextBlock Text="环境过滤" FontSize="14" FontWeight="Bold" Foreground="#45AFFF" Margin="0,0,0,12"/>
                             
                             <CheckBox Name="CheckEnvironmentFilter" Content="启用智能环境探测" Style="{StaticResource ToggleSwitch}" Margin="0,0,0,10" Checked="EnvironmentFilterSetting_Changed" Unchecked="EnvironmentFilterSetting_Changed"/>
-                            <CheckBox Name="CheckHideInFullscreen" Content="全屏应用前台运行时自动暂停" Style="{StaticResource ToggleSwitch}" Margin="0,0,0,15"/>
+                            <CheckBox Name="CheckHideInFullscreen" Content="全屏应用前台运行时自动暂停" Style="{StaticResource ToggleSwitch}" Margin="0,0,0,10"/>
+                            <CheckBox Name="CheckShowEffectOnDesktop" Content="在桌面上显示特效" Style="{StaticResource ToggleSwitch}" Margin="0,0,0,15"/>
 
                             <Separator Background="#F0F2F5" Margin="0,5,0,15"/>
 
-                            <TextBlock Text="应用过滤 (名单管理)" FontWeight="SemiBold" Foreground="#333" Margin="0,0,0,10"/>
-                            <ComboBox Name="ComboProcessFilterMode" Width="180" Margin="0,0,0,12" SelectionChanged="ProcessFilterMode_Changed" Height="28" VerticalContentAlignment="Center">
+                            <TextBlock Text="配置组管理" FontWeight="SemiBold" Foreground="#333" Margin="0,0,0,10"/>
+                            <DockPanel Margin="0,0,0,12">
+                                <Button Content="删除" Click="DeleteProfile_Click" DockPanel.Dock="Right" Margin="5,0,0,0" Padding="8,0" Height="28" Background="#FFF0F0" Foreground="#CC0000" BorderBrush="#FFCCCC">
+                                    <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="4"/></Style></Button.Resources>
+                                </Button>
+                                <Button Content="重命名" Click="RenameProfile_Click" DockPanel.Dock="Right" Margin="5,0,0,0" Padding="8,0" Height="28" Background="#F8FAFF" BorderBrush="#D6DEE8">
+                                    <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="4"/></Style></Button.Resources>
+                                </Button>
+                                <Button Content="新建" Click="AddProfile_Click" DockPanel.Dock="Right" Margin="5,0,0,0" Padding="8,0" Height="28" Background="#F8FAFF" BorderBrush="#D6DEE8">
+                                    <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="4"/></Style></Button.Resources>
+                                </Button>
+                                <ComboBox Name="ComboProfiles" SelectionChanged="ComboProfiles_SelectionChanged" Height="28" VerticalContentAlignment="Center">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Name}"/>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                            </DockPanel>
+
+                            <TextBlock Text="过滤模式" FontWeight="SemiBold" Foreground="#333" Margin="0,0,0,10"/>
+                            <ComboBox Name="ComboProcessFilterMode" Width="180" Margin="0,0,0,12" SelectionChanged="ProcessFilterMode_Changed" Height="28" VerticalContentAlignment="Center" HorizontalAlignment="Left">
                                 <ComboBoxItem Content="🚫 关闭过滤" Tag="Disabled"/>
                                 <ComboBoxItem Content="❌ 黑名单模式" Tag="Blacklist"/>
                                 <ComboBoxItem Content="✅ 白名单模式" Tag="Whitelist"/>
                             </ComboBox>
 
-                            <Grid Margin="0,0,0,8">
-                                <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/></Grid.ColumnDefinitions>
-                                <TextBox x:Name="SearchProcess" Height="30" Padding="26,0,5,0" VerticalContentAlignment="Center" TextChanged="SearchProcess_TextChanged" Background="#F8FAFF" BorderBrush="#D6DEE8">
-                                    <TextBox.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></TextBox.Resources>
-                                </TextBox>
-                                <TextBlock Text="🔍" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="8,0,0,0" Foreground="#AAA" IsHitTestVisible="False"/>
-                                <Button Grid.Column="1" Content="刷新列表" Margin="8,0,0,0" Padding="12,0" Height="30" Click="RefreshProcessList_Click" Background="White">
-                                    <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></Button.Resources>
-                                </Button>
-                            </Grid>
-                            
-                            <ListBox Name="ListProcessSelection" Height="140" Background="#FDFDFF" BorderBrush="#E0E8F0" BorderThickness="1">
+                            <TextBlock Text="已配置进程列表" FontWeight="SemiBold" Foreground="#333" Margin="0,0,0,10"/>
+                            <ListBox Name="ListConfiguredProcesses" Height="120" Background="#FDFDFF" BorderBrush="#E0E8F0" BorderThickness="1" Margin="0,0,0,10">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate>
-                                        <CheckBox IsChecked="{Binding IsSelected}" Margin="2,4" VerticalContentAlignment="Center">
-                                            <StackPanel Orientation="Vertical" Margin="8,0,0,0">
-                                                <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" FontSize="13" Foreground="#333"/>
-                                                <TextBlock Text="{Binding ProcessName}" FontSize="10" Foreground="#999"/>
-                                            </StackPanel>
-                                        </CheckBox>
+                                        <DockPanel LastChildFill="True" Margin="2">
+                                            <Button Content="移除" Click="RemoveProcess_Click" DockPanel.Dock="Right" Padding="5,0" Height="22" FontSize="11" Background="#FFF0F0" Foreground="#CC0000" BorderBrush="#FFCCCC">
+                                                <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="3"/></Style></Button.Resources>
+                                            </Button>
+                                            <TextBlock Text="{Binding}" VerticalAlignment="Center" Margin="5,0"/>
+                                        </DockPanel>
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
                             </ListBox>
+
+                            <TextBlock Text="添加进程" FontWeight="SemiBold" Foreground="#333" Margin="0,0,0,10"/>
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox x:Name="ManualProcessInput" Height="30" VerticalContentAlignment="Center" Background="#F8FAFF" BorderBrush="#D6DEE8" Padding="5,0">
+                                    <TextBox.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></TextBox.Resources>
+                                </TextBox>
+                                <Button Grid.Column="1" Content="添加" Margin="5,0,0,0" Padding="12,0" Height="30" Click="AddManualProcess_Click" Background="#45AFFF" Foreground="White">
+                                    <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></Button.Resources>
+                                </Button>
+                                <Button Grid.Column="2" Content="浏览..." Margin="5,0,0,0" Padding="12,0" Height="30" Click="BrowseProcess_Click" Background="White">
+                                    <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></Button.Resources>
+                                </Button>
+                                <Button Grid.Column="3" Content="从运行中选择" Margin="5,0,0,0" Padding="12,0" Height="30" Click="SelectRunningProcess_Click" Background="White">
+                                    <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></Button.Resources>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </Border>
                     
@@ -395,5 +428,50 @@
                 
             </Grid>
         </ScrollViewer>
+
+        <!-- 运行中进程选择弹窗 (Overlay) -->
+        <Grid Name="RunningProcessOverlay" Grid.ColumnSpan="2" Background="#80000000" Visibility="Collapsed">
+            <Border Background="White" CornerRadius="12" Width="400" Height="500" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="20">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    
+                    <TextBlock Text="从运行中进程添加" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
+                    
+                    <Grid Grid.Row="1" Margin="0,0,0,10">
+                        <TextBox x:Name="SearchRunningProcess" Height="30" VerticalContentAlignment="Center" TextChanged="SearchRunningProcess_TextChanged" Background="#F8FAFF" BorderBrush="#D6DEE8" Padding="26,0,5,0">
+                            <TextBox.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></TextBox.Resources>
+                        </TextBox>
+                        <TextBlock Text="🔍" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="8,0,0,0" Foreground="#AAA" IsHitTestVisible="False"/>
+                    </Grid>
+
+                    <ListBox Name="ListRunningProcesses" Grid.Row="2" Background="#FDFDFF" BorderBrush="#E0E8F0" BorderThickness="1">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding IsSelected}" Margin="2,4" VerticalContentAlignment="Center">
+                                    <StackPanel Orientation="Vertical" Margin="8,0,0,0">
+                                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" FontSize="13" Foreground="#333"/>
+                                        <TextBlock Text="{Binding ProcessName}" FontSize="10" Foreground="#999"/>
+                                    </StackPanel>
+                                </CheckBox>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
+                    <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
+                        <Button Content="取消" Click="CloseRunningProcessOverlay_Click" Width="80" Height="32" Background="White" BorderBrush="#DDD" Margin="0,0,10,0">
+                            <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></Button.Resources>
+                        </Button>
+                        <Button Content="确认添加" Click="ConfirmAddRunningProcesses_Click" Width="100" Height="32" Background="#45AFFF" Foreground="White" BorderThickness="0">
+                            <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></Button.Resources>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
     </Grid>
 </Window>

--- a/src/ControlPanelWindow.xaml
+++ b/src/ControlPanelWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="BASpark.ControlPanelWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="BASpark - 控制面板" Height="650" Width="680"
+        Title="BASpark - 控制面板" Height="710" Width="680"
         WindowStartupLocation="CenterScreen" Background="#F5F7FA" Icon="app.ico">
 
     <Window.Resources>
@@ -151,7 +151,25 @@
                 </StackPanel>
 
                 <StackPanel Name="PageSettings" Visibility="Collapsed">
-                    <TextBlock Text="参数配置" FontSize="24" FontWeight="Bold" Margin="0,0,0,20" Foreground="#333"/>
+                <Grid Margin="0,0,0,25">
+                <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0" Text="参数配置" FontSize="24" FontWeight="Bold" Foreground="#333" VerticalAlignment="Center"/>
+
+                    <Button Grid.Column="1" Content="应用更改" Click="SaveSettings_Click" Width="120" Height="36" Background="#45AFFF" Foreground="White" BorderThickness="0" Cursor="Hand" FontWeight="Bold" FontSize="14">
+                        <Button.Resources>
+                            <Style TargetType="Border">
+                                <Setter Property="CornerRadius" Value="18"/>
+                            </Style>
+                        </Button.Resources>
+                        <Button.Effect>
+                            <DropShadowEffect BlurRadius="8" ShadowDepth="1" Opacity="0.15"/>
+                        </Button.Effect>
+                    </Button>
+                </Grid>
 
                 <StackPanel>
                     <StackPanel.Style>
@@ -189,14 +207,6 @@
                             </StackPanel>
                         </StackPanel>
                     </Border>
-
-                    <Button Content="应用更改" Click="SaveSettings_Click" Width="180" Height="42" Background="#45AFFF" Foreground="White" BorderThickness="0" Cursor="Hand" HorizontalAlignment="Left" FontWeight="Bold" FontSize="15">
-                        <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="8"/></Style></Button.Resources>
-                        <Button.Effect>
-                            <DropShadowEffect BlurRadius="10" ShadowDepth="2" Opacity="0.2"/>
-                        </Button.Effect>
-                    </Button>
-                    <Rectangle Height="40"/>
                 </StackPanel>
 
                 <StackPanel>
@@ -286,15 +296,7 @@
                             </StackPanel>
                         </StackPanel>
                     </Border>
-
-                        <Button Content="应用更改" Click="SaveSettings_Click" Width="180" Height="42" Background="#45AFFF" Foreground="White" BorderThickness="0" Cursor="Hand" HorizontalAlignment="Left" FontWeight="Bold" FontSize="15">
-                            <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="8"/></Style></Button.Resources>
-                            <Button.Effect>
-                                <DropShadowEffect BlurRadius="10" ShadowDepth="2" Opacity="0.2"/>
-                            </Button.Effect>
-                        </Button>
-                        <Rectangle Height="40"/>
-                    </StackPanel>
+                </StackPanel>
 
                     <StackPanel>
                         <StackPanel.Style>
@@ -382,14 +384,6 @@
                             </Grid>
                         </StackPanel>
                     </Border>
-                    
-                    <Button Content="应用更改" Click="SaveSettings_Click" Width="180" Height="42" Background="#45AFFF" Foreground="White" BorderThickness="0" Cursor="Hand" HorizontalAlignment="Left" FontWeight="Bold" FontSize="15">
-                        <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="8"/></Style></Button.Resources>
-                        <Button.Effect>
-                            <DropShadowEffect BlurRadius="10" ShadowDepth="2" Opacity="0.2"/>
-                        </Button.Effect>
-                    </Button>
-                    <Rectangle Height="40"/>
                 </StackPanel>
 
                 </StackPanel>
@@ -471,6 +465,26 @@
                         </Button>
                     </StackPanel>
                 </Grid>
+            </Border>
+        </Grid>
+
+        <Grid Name="RenameProfileOverlay" Grid.ColumnSpan="2" Background="#80000000" Visibility="Collapsed">
+            <Border Background="White" CornerRadius="12" Width="350" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="20">
+                <StackPanel>
+                    <TextBlock Text="重命名配置组" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
+                    <TextBlock Text="请输入新的配置组名称：" FontSize="13" Foreground="#666" Margin="0,0,0,10"/>
+                    <TextBox x:Name="NewProfileNameInput" Height="32" VerticalContentAlignment="Center" Background="#F8FAFF" BorderBrush="#D6DEE8" Padding="8,0">
+                        <TextBox.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></TextBox.Resources>
+                    </TextBox>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+                        <Button Content="取消" Click="CloseRenameOverlay_Click" Width="80" Height="32" Background="White" BorderBrush="#DDD" Margin="0,0,10,0">
+                            <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></Button.Resources>
+                        </Button>
+                        <Button Content="确认修改" Click="ConfirmRenameProfile_Click" Width="100" Height="32" Background="#45AFFF" Foreground="White" BorderThickness="0">
+                            <Button.Resources><Style TargetType="Border"><Setter Property="CornerRadius" Value="6"/></Style></Button.Resources>
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
             </Border>
         </Grid>
     </Grid>

--- a/src/ControlPanelWindow.xaml.cs
+++ b/src/ControlPanelWindow.xaml.cs
@@ -34,16 +34,17 @@ namespace BASpark
         private DispatcherTimer _noticeTimer;
         private bool _isCheckingUpdate = false;
 
-        public ObservableCollection<ProcessItem> ProcessList { get; set; } = new ObservableCollection<ProcessItem>();
+        public ObservableCollection<FilterProfile> Profiles { get; set; } = new ObservableCollection<FilterProfile>();
+        public ObservableCollection<string> CurrentProfileProcesses { get; set; } = new ObservableCollection<string>();
+        public ObservableCollection<ProcessItem> RunningProcessList { get; set; } = new ObservableCollection<ProcessItem>();
 
         public ControlPanelWindow()
         {
             InitializeComponent();
             
-            if (ListProcessSelection != null)
-            {
-                ListProcessSelection.ItemsSource = ProcessList;
-            }
+            ComboProfiles.ItemsSource = Profiles;
+            ListConfiguredProcesses.ItemsSource = CurrentProfileProcesses;
+            ListRunningProcesses.ItemsSource = RunningProcessList;
 
             LoadVersion();
             LoadSettings();
@@ -88,10 +89,10 @@ namespace BASpark
                 if (textBox != null)
                 {
                     System.Windows.Input.Keyboard.ClearFocus();
-                var binding = System.Windows.Data.BindingOperations.GetBindingExpression(textBox, System.Windows.Controls.TextBox.TextProperty);
-                binding?.UpdateSource();
+                    var binding = System.Windows.Data.BindingOperations.GetBindingExpression(textBox, System.Windows.Controls.TextBox.TextProperty);
+                    binding?.UpdateSource();
                 }
-            e.Handled = true;
+                e.Handled = true;
             }
         }
 
@@ -289,15 +290,9 @@ namespace BASpark
             }
         }
 
-        private void RefreshProcessList_Click(object sender, RoutedEventArgs e)
+        private void RefreshRunningProcessList()
         {
-            RefreshProcessList();
-        }
-
-        private void RefreshProcessList()
-        {
-            var currentlySelected = ProcessList.Where(p => p.IsSelected).Select(p => p.ProcessName).ToList();
-            ProcessList.Clear();
+            RunningProcessList.Clear();
             try
             {
                 var processes = Process.GetProcesses()
@@ -307,7 +302,7 @@ namespace BASpark
                 foreach (var p in processes)
                 {
                     string pName = p.ProcessName + ".exe";
-                    if (ProcessList.Any(item => item.ProcessName.Equals(pName, StringComparison.OrdinalIgnoreCase))) continue;
+                    if (RunningProcessList.Any(item => item.ProcessName.Equals(pName, StringComparison.OrdinalIgnoreCase))) continue;
 
                     string dName = pName;
                     try 
@@ -317,21 +312,21 @@ namespace BASpark
                     } 
                     catch { }
 
-                    ProcessList.Add(new ProcessItem
+                    RunningProcessList.Add(new ProcessItem
                     {
                         DisplayName = dName,
                         ProcessName = pName,
-                        IsSelected = currentlySelected.Contains(pName, StringComparer.OrdinalIgnoreCase)
+                        IsSelected = false
                     });
                 }
             }
             catch (Exception ex) { Debug.WriteLine(ex.Message); }
         }
 
-        private void SearchProcess_TextChanged(object sender, TextChangedEventArgs e)
+        private void SearchRunningProcess_TextChanged(object sender, TextChangedEventArgs e)
         {
             string? filter = (sender as System.Windows.Controls.TextBox)?.Text;
-            ICollectionView view = CollectionViewSource.GetDefaultView(ProcessList);
+            ICollectionView view = CollectionViewSource.GetDefaultView(RunningProcessList);
             if (view == null) return;
 
             if (string.IsNullOrWhiteSpace(filter))
@@ -361,29 +356,15 @@ namespace BASpark
             CheckAlwaysTrailEffectSwitch.IsChecked = ConfigManager.EnableAlwaysTrailEffect;
             CheckEnvironmentFilter.IsChecked = ConfigManager.EnableEnvironmentFilter;
             CheckHideInFullscreen.IsChecked = ConfigManager.HideInFullscreen;
+            CheckShowEffectOnDesktop.IsChecked = ConfigManager.ShowEffectOnDesktop;
             CheckRunAsAdmin.IsChecked = ConfigManager.RunAsAdmin; 
             CheckTouchscreenMode.IsChecked = ConfigManager.IsTouchscreenMode;
 
-            SelectProcessFilterMode(ConfigManager.ProcessFilterMode);
-            
-            string savedList = ConfigManager.ProcessFilterList ?? "";
-            var savedNames = savedList.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
-                                      .Select(s => s.Trim()).ToList();
+            Profiles.Clear();
+            foreach (var p in ConfigManager.GetProfiles()) Profiles.Add(p);
 
-            RefreshProcessList();
-
-            foreach (var name in savedNames)
-            {
-                var existing = ProcessList.FirstOrDefault(p => p.ProcessName.Equals(name, StringComparison.OrdinalIgnoreCase));
-                if (existing == null)
-                {
-                    ProcessList.Insert(0, new ProcessItem { DisplayName = name, ProcessName = name, IsSelected = true });
-                }
-                else
-                {
-                    existing.IsSelected = true;
-                }
-            }
+            var active = ConfigManager.GetActiveProfile();
+            ComboProfiles.SelectedItem = active;
 
             UpdateColorPreview(ConfigManager.ParticleColor);
             UpdateStartSilentInterlock();
@@ -393,7 +374,6 @@ namespace BASpark
             SliderOpacity.Value = ConfigManager.EffectOpacity * 100;
             SliderSpeed.Value = ConfigManager.EffectSpeed;
             SliderTrailRefresh.Value = ConfigManager.TrailRefreshRate;
-            UpdateEffectValueTexts();
         }
 
         private void CheckAutoStart_Changed(object sender, RoutedEventArgs e)
@@ -427,6 +407,10 @@ namespace BASpark
         private void ProcessFilterMode_Changed(object sender, SelectionChangedEventArgs e)
         {
             if (!IsLoaded) return;
+            if (ComboProfiles.SelectedItem is FilterProfile active)
+            {
+                active.Mode = GetSelectedProcessFilterMode();
+            }
             UpdateEnvironmentFilterInterlock();
         }
 
@@ -437,13 +421,16 @@ namespace BASpark
             bool processFilterEnabled = environmentFilterEnabled && selectedMode != ProcessFilterModeOption.Disabled;
 
             CheckHideInFullscreen.IsEnabled = environmentFilterEnabled;
+            CheckShowEffectOnDesktop.IsEnabled = environmentFilterEnabled;
+            ComboProfiles.IsEnabled = environmentFilterEnabled;
             ComboProcessFilterMode.IsEnabled = environmentFilterEnabled;
             
-            if (ListProcessSelection != null)
+            if (ListConfiguredProcesses != null)
             {
-                ListProcessSelection.IsEnabled = processFilterEnabled;
-                ListProcessSelection.Opacity = processFilterEnabled ? 1.0 : 0.65;
+                ListConfiguredProcesses.IsEnabled = processFilterEnabled;
+                ListConfiguredProcesses.Opacity = processFilterEnabled ? 1.0 : 0.65;
             }
+            ManualProcessInput.IsEnabled = processFilterEnabled;
         }
 
         private void SelectProcessFilterMode(ProcessFilterModeOption mode)
@@ -463,35 +450,6 @@ namespace BASpark
                 return mode;
             }
             return ProcessFilterModeOption.Disabled;
-        }
-
-        private void UpdateEffectValueTexts()
-        {
-        }
-
-        private void EffectSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
-        {
-            if (!IsLoaded) return;
-        }
-
-        private void UpdateColorPreview(string rgbString)
-        {
-            try
-            {
-                var parts = rgbString.Split(',');
-                if (parts.Length == 3)
-                {
-                    byte r = byte.Parse(parts[0].Trim());
-                    byte g = byte.Parse(parts[1].Trim());
-                    byte b = byte.Parse(parts[2].Trim());
-                    ColorPreview.Background = new System.Windows.Media.SolidColorBrush(
-                        System.Windows.Media.Color.FromRgb(r, g, b));
-                }
-            }
-            catch
-            {
-                ColorPreview.Background = System.Windows.Media.Brushes.Gray;
-            }
         }
 
         private void Tab_Click(object sender, RoutedEventArgs e)
@@ -526,6 +484,26 @@ namespace BASpark
             }
         }
 
+        private void UpdateColorPreview(string rgbString)
+        {
+            try
+            {
+                var parts = rgbString.Split(',');
+                if (parts.Length == 3)
+                {
+                    byte r = byte.Parse(parts[0].Trim());
+                    byte g = byte.Parse(parts[1].Trim());
+                    byte b = byte.Parse(parts[2].Trim());
+                    ColorPreview.Background = new System.Windows.Media.SolidColorBrush(
+                        System.Windows.Media.Color.FromRgb(r, g, b));
+                }
+            }
+            catch
+            {
+                ColorPreview.Background = System.Windows.Media.Brushes.Gray;
+            }
+        }
+
         private void OpenLink_Click(object sender, RoutedEventArgs e)
         {
             if (sender is System.Windows.Controls.Button btn && btn.Tag is string url)
@@ -534,6 +512,136 @@ namespace BASpark
                 catch (Exception ex)
                 {
                     System.Windows.MessageBox.Show("无法打开链接: " + ex.Message);
+                }
+            }
+        }
+
+        // --- 配置组管理 ---
+        private void ComboProfiles_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (ComboProfiles.SelectedItem is FilterProfile selected)
+            {
+                CurrentProfileProcesses.Clear();
+                foreach (var p in selected.Processes) CurrentProfileProcesses.Add(p);
+                SelectProcessFilterMode(selected.Mode);
+                UpdateEnvironmentFilterInterlock();
+            }
+        }
+
+        private void AddProfile_Click(object sender, RoutedEventArgs e)
+        {
+            var newProfile = new FilterProfile { Name = "新配置组 " + (Profiles.Count + 1) };
+            Profiles.Add(newProfile);
+            ComboProfiles.SelectedItem = newProfile;
+        }
+
+        private void RenameProfile_Click(object sender, RoutedEventArgs e)
+        {
+            if (ComboProfiles.SelectedItem is FilterProfile active)
+            {
+                // 简易重命名逻辑，实际项目中可使用自定义输入框
+                string newName = Microsoft.VisualBasic.Interaction.InputBox("输入新名称:", "重命名配置组", active.Name);
+                if (!string.IsNullOrWhiteSpace(newName))
+                {
+                    active.Name = newName;
+                    // 刷新 ComboBox 显示
+                    int index = Profiles.IndexOf(active);
+                    Profiles.RemoveAt(index);
+                    Profiles.Insert(index, active);
+                    ComboProfiles.SelectedItem = active;
+                }
+            }
+        }
+
+        private void DeleteProfile_Click(object sender, RoutedEventArgs e)
+        {
+            if (Profiles.Count <= 1)
+            {
+                System.Windows.MessageBox.Show("至少需要保留一个配置组。", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            if (ComboProfiles.SelectedItem is FilterProfile active)
+            {
+                if (System.Windows.MessageBox.Show($"确定要删除 '{active.Name}' 吗？", "确认删除", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                {
+                    Profiles.Remove(active);
+                    ComboProfiles.SelectedIndex = 0;
+                }
+            }
+        }
+
+        // --- 进程管理 ---
+        private void RemoveProcess_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is System.Windows.Controls.Button btn && btn.DataContext is string processName)
+            {
+                CurrentProfileProcesses.Remove(processName);
+                if (ComboProfiles.SelectedItem is FilterProfile active)
+                {
+                    active.Processes.Remove(processName);
+                }
+            }
+        }
+
+        private void AddManualProcess_Click(object sender, RoutedEventArgs e)
+        {
+            string input = ManualProcessInput.Text.Trim().ToLowerInvariant();
+            if (string.IsNullOrEmpty(input)) return;
+            if (!input.EndsWith(".exe")) input += ".exe";
+
+            AddProcessToActiveProfile(input);
+            ManualProcessInput.Clear();
+        }
+
+        private void BrowseProcess_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Filter = "可执行文件 (*.exe)|*.exe",
+                Title = "选择应用进程"
+            };
+
+            if (dialog.ShowDialog() == true)
+            {
+                string fileName = System.IO.Path.GetFileName(dialog.FileName).ToLowerInvariant();
+                AddProcessToActiveProfile(fileName);
+            }
+        }
+
+        private void SelectRunningProcess_Click(object sender, RoutedEventArgs e)
+        {
+            RefreshRunningProcessList();
+            RunningProcessOverlay.Visibility = Visibility.Visible;
+        }
+
+        private void CloseRunningProcessOverlay_Click(object sender, RoutedEventArgs e)
+        {
+            RunningProcessOverlay.Visibility = Visibility.Collapsed;
+        }
+
+        private void ConfirmAddRunningProcesses_Click(object sender, RoutedEventArgs e)
+        {
+            var selected = RunningProcessList.Where(p => p.IsSelected).Select(p => p.ProcessName).ToList();
+            foreach (var p in selected)
+            {
+                AddProcessToActiveProfile(p);
+            }
+            RunningProcessOverlay.Visibility = Visibility.Collapsed;
+        }
+
+        private void AddProcessToActiveProfile(string processName)
+        {
+            if (ComboProfiles.SelectedItem is FilterProfile active)
+            {
+                if (!active.Processes.Contains(processName, StringComparer.OrdinalIgnoreCase))
+                {
+                    active.Processes.Add(processName);
+                    CurrentProfileProcesses.Add(processName);
+                }
+                else
+                {
+                    // 已存在，不重复添加
                 }
             }
         }
@@ -548,11 +656,10 @@ namespace BASpark
             bool startSilentEnabled = CheckStartSilent.IsChecked ?? false;
             bool runAsAdminEnabled = CheckRunAsAdmin.IsChecked ?? false;
             bool isTouchscreenEnabled = CheckTouchscreenMode?.IsChecked ?? false;
-            ProcessFilterModeOption processFilterMode = GetSelectedProcessFilterMode();
             
-            string selectedProcesses = string.Join(Environment.NewLine, 
-                ProcessList.Where(p => p.IsSelected).Select(p => p.ProcessName));
-            string normalizedProcessFilterList = ConfigManager.NormalizeProcessFilterList(selectedProcesses);
+            // 保存配置组
+            string activeId = (ComboProfiles.SelectedItem as FilterProfile)?.Id ?? "";
+            ConfigManager.SaveProfiles(Profiles.ToList(), activeId);
 
             ConfigManager.Save("RunAsAdmin", runAsAdminEnabled);
             ConfigManager.Save("IsTouchscreenMode", isTouchscreenEnabled);
@@ -569,8 +676,7 @@ namespace BASpark
             ConfigManager.Save("StartSilent", startSilentEnabled);
             ConfigManager.Save("EnableEnvironmentFilter", CheckEnvironmentFilter.IsChecked ?? false);
             ConfigManager.Save("HideInFullscreen", CheckHideInFullscreen.IsChecked ?? true);
-            ConfigManager.Save("ProcessFilterMode", processFilterMode.ToString());
-            ConfigManager.Save("ProcessFilterList", normalizedProcessFilterList);
+            ConfigManager.Save("ShowEffectOnDesktop", CheckShowEffectOnDesktop.IsChecked ?? true);
 
             App.SetAutoStart(ConfigManager.AutoStart);
             ApplyAutoStartSettings();
@@ -708,6 +814,11 @@ namespace BASpark
         {
             ConfigManager.Save("TotalClicks", ConfigManager.TotalClicks);
             base.OnClosing(e);
+        }
+
+        private void EffectSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (!IsLoaded) return;
         }
 
         private void ResetConfig_Click(object sender, RoutedEventArgs e)

--- a/src/ControlPanelWindow.xaml.cs
+++ b/src/ControlPanelWindow.xaml.cs
@@ -539,18 +539,36 @@ namespace BASpark
         {
             if (ComboProfiles.SelectedItem is FilterProfile active)
             {
-                // 简易重命名逻辑，实际项目中可使用自定义输入框
-                string newName = Microsoft.VisualBasic.Interaction.InputBox("输入新名称:", "重命名配置组", active.Name);
-                if (!string.IsNullOrWhiteSpace(newName))
+                // 使用自定义输入框
+                NewProfileNameInput.Text = active.Name;
+                RenameProfileOverlay.Visibility = Visibility.Visible;
+                NewProfileNameInput.Focus();
+                NewProfileNameInput.SelectAll();
+            }
+        }
+
+        private void ConfirmRenameProfile_Click(object sender, RoutedEventArgs e)
+        {
+            string newName = NewProfileNameInput.Text.Trim();
+            
+            if (!string.IsNullOrWhiteSpace(newName) && ComboProfiles.SelectedItem is FilterProfile active)
+            {
+                active.Name = newName;
+                // 刷新 ComboBox 显示
+                int index = Profiles.IndexOf(active);
+                if (index != -1)
                 {
-                    active.Name = newName;
-                    // 刷新 ComboBox 显示
-                    int index = Profiles.IndexOf(active);
                     Profiles.RemoveAt(index);
                     Profiles.Insert(index, active);
                     ComboProfiles.SelectedItem = active;
                 }
             }
+            RenameProfileOverlay.Visibility = Visibility.Collapsed;
+        }
+
+        private void CloseRenameOverlay_Click(object sender, RoutedEventArgs e)
+        {
+            RenameProfileOverlay.Visibility = Visibility.Collapsed;
         }
 
         private void DeleteProfile_Click(object sender, RoutedEventArgs e)

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -396,6 +396,23 @@ namespace BASpark
                 return _isSuppressedByEnvironment;
             }
 
+            // 桌面判断逻辑
+            string className = GetWindowClassName(targetWindow);
+            if (string.IsNullOrEmpty(className))
+            {
+                className = GetWindowClassName(GetForegroundWindow());
+            }
+
+            bool isDesktop = string.Equals(className, "Progman", StringComparison.OrdinalIgnoreCase) ||
+                             string.Equals(className, "WorkerW", StringComparison.OrdinalIgnoreCase) ||
+                             string.Equals(className, "SHELLDLL_DefView", StringComparison.OrdinalIgnoreCase);
+
+            if (isDesktop)
+            {
+                UpdateSuppressionState(nowTicks, !ConfigManager.ShowEffectOnDesktop);
+                return _isSuppressedByEnvironment;
+            }
+
             if (!TryGetForegroundProcessName(targetWindow, out string processName))
             {
                 if (!TryGetForegroundProcessName(GetForegroundWindow(), out processName))
@@ -426,20 +443,14 @@ namespace BASpark
 
         private bool IsSuppressedByProcessFilter(string processName)
         {
-            ProcessFilterModeOption mode = ConfigManager.ProcessFilterMode;
-            if (mode == ProcessFilterModeOption.Disabled)
+            var profile = ConfigManager.GetActiveProfile();
+            if (profile == null || profile.Mode == ProcessFilterModeOption.Disabled)
             {
                 return false;
             }
 
-            var filterEntries = ConfigManager.GetProcessFilterEntries();
-            if (filterEntries.Count == 0)
-            {
-                return false;
-            }
-
-            bool isListed = filterEntries.Contains(processName);
-            return mode switch
+            bool isListed = profile.Processes.Contains(processName, StringComparer.OrdinalIgnoreCase);
+            return profile.Mode switch
             {
                 ProcessFilterModeOption.Blacklist => isListed,
                 ProcessFilterModeOption.Whitelist => !isListed,


### PR DESCRIPTION
本 PR 对过滤规则管理、桌面显示控制以及进程配置界面进行了重构与增强，主要提升了多场景配置能力、桌面判定准确性以及进程管理体验。

### 主要变更

#### 多配置组管理
- 支持创建、重命名、删除多个独立配置组
- 每个配置组独立保存过滤模式（黑名单/白名单）及进程列表
- 支持在不同配置组之间快速切换，适配不同使用场景

#### 桌面独立控制
- 新增“在桌面上显示特效”全局开关
- 通过识别 `Progman` / `WorkerW` 类名精确判断桌面环境
- 桌面是否显示特效不再依赖黑白名单匹配结果

#### 进程列表与配置体验重构
- 已配置进程在列表中持久显示，不再因进程退出而丢失勾选状态
- 支持手动输入进程名添加
- 支持通过文件选择器选取 `.exe` 添加
- 新增“从运行中添加”弹窗，支持从当前运行程序中检索并批量添加

### 技术实现
- 使用 JSON 序列化将配置组存储至注册表
- 增加旧版单列表配置的自动迁移逻辑
- 在前台窗口探测中加入桌面短路判定，命中桌面类名时跳过后续匹配流程，降低 CPU 开销
- 引入 `Microsoft.VisualBasic` 以支持便捷命名输入
- 重构控制面板 Tab 联动逻辑，优化不同模式下的配置项显示与交互

### 涉及文件
- `ConfigManager.cs`
- `MainWindow.xaml.cs`
- `ControlPanelWindow.xaml`
- `ControlPanelWindow.xaml.cs`
- `BASpark.csproj`
