### PR TITLE
fix: 防止全屏特效层触发 Windows 请勿打扰模式

### DIFF
--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -108,6 +108,7 @@ namespace BASpark
         private const int WS_EX_TRANSPARENT = 0x00000020;
         private const int WS_EX_LAYERED = 0x00080000;
         private const int WS_EX_TOOLWINDOW = 0x00000080;
+        private const int WS_EX_NOACTIVATE = 0x08000000;
 
         private const Int32 CURSOR_SHOWING = 0x00000001; // 光标可见状态码
         private const int SM_XVIRTUALSCREEN = 76;
@@ -165,7 +166,7 @@ namespace BASpark
             base.OnSourceInitialized(e);
             _hwnd = new WindowInteropHelper(this).Handle;
             int style = GetWindowLong(_hwnd, GWL_EXSTYLE);
-            SetWindowLong(_hwnd, GWL_EXSTYLE, style | WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_TOOLWINDOW);
+            SetWindowLong(_hwnd, GWL_EXSTYLE, style | WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE);
 
             UpdateOverlayBounds();
             SystemEvents.DisplaySettingsChanged += HandleDisplaySettingsChanged;

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -583,7 +583,7 @@ namespace BASpark
                 _virtualScreenLeft,
                 _virtualScreenTop,
                 _virtualScreenWidth,
-                _virtualScreenHeight,
+                _virtualScreenHeight - 1,
                 SWP_NOACTIVATE);
         }
 


### PR DESCRIPTION
### PR 描述

本 PR 修复了 BASpark 特效层在 Windows 下被系统误判为全屏应用、从而自动触发“请勿打扰”模式的问题。该问题会导致系统通知被静默处理，影响用户正常接收通知消息。

### 问题背景

由于 BASpark 的特效层本质上是一个覆盖全屏的顶层窗口，Windows 的启发式检测机制可能将其识别为正在全屏运行的应用程序，类似于游戏或演示文稿场景。在这种情况下，系统会自动启用“请勿打扰”（Focus Assist / Do Not Disturb），导致通知被屏蔽，影响日常使用体验。

### 解决方案

本 PR 采用了组合修复方案，在不影响现有视觉效果和交互逻辑的前提下，规避系统对全屏窗口的误判。

首先，为窗口增加了 `WS_EX_NOACTIVATE` 扩展样式，以进一步表明该窗口属于非激活的展示层，而非用户正在直接交互的前台全屏应用。

其次，在 `UpdateOverlayBounds` 中调整窗口尺寸时，将窗口高度设置为 `_virtualScreenHeight - 1`。该方案利用了 Windows 全屏检测依赖“窗口尺寸是否与显示器分辨率完全一致”的行为特征。通过仅减少 1 像素，使窗口不再满足“完全覆盖屏幕”的判定条件，从而避免触发系统的“请勿打扰”逻辑。

从用户体验角度看，这 1 像素的尺寸差异在视觉上基本不可察觉，但可以有效规避系统误判，达到修复目的。

### 改动内容

- `MainWindow.xaml.cs`
  - 增加 `WS_EX_NOACTIVATE` 常量并在窗口初始化时应用
  - 修改 `UpdateOverlayBounds` 方法中的 `SetWindowPos` 调用，将高度参数调整为 `_virtualScreenHeight - 1`

### 测试情况

已在 Windows 11 环境下进行验证。

测试结果表明，在应用启动后，系统不再因 BASpark 的特效层自动开启“请勿打扰”模式，系统通知能够正常显示和接收。
