### PR TITLE
feat: 截图兼容模式支持微信

### DIFF
--- a/src/ControlPanelWindow.xaml
+++ b/src/ControlPanelWindow.xaml
@@ -451,7 +451,7 @@
                                         <CheckBox Name="CheckMiddleClickTrigger" Content="鼠标中键按下时触发特效" Style="{StaticResource ToggleSwitch}" Margin="0,10,0,0"/>
                                     </StackPanel>
                                     <CheckBox Name="CheckScreenshotCompatibilityMode" Content="截图兼容模式" Style="{StaticResource ToggleSwitch}" Margin="0,0,0,2"/>
-                                    <TextBlock x:Name="TxtScreenshotHint" Text="* (实验性功能) 开启后截图画面将不包含特效：检测到系统截图界面或 QQ 默认截图快捷键时会短暂隐藏叠加层以便框选窗口。" FontSize="11" Foreground="#9BA3AF" Margin="34,0,0,12" TextWrapping="Wrap" Opacity="0.8"/>
+                                    <TextBlock x:Name="TxtScreenshotHint" Text="* (实验性功能) 开启后截图画面将不包含特效：检测到系统截图界面、QQ 默认截图快捷键 (Ctrl+Alt+A) 或微信截图快捷键 (Alt+A) 时会短暂隐藏叠加层以便框选窗口。" FontSize="11" Foreground="#9BA3AF" Margin="34,0,0,12" TextWrapping="Wrap" Opacity="0.8"/>
                                     <CheckBox Name="CheckAutoStart" Content="开机自动启动" Style="{StaticResource ToggleSwitch}" Margin="0,0,0,8" Checked="CheckAutoStart_Changed" Unchecked="CheckAutoStart_Changed"/>
                                     <CheckBox Name="CheckStartSilent" Content="静默启动 (最小化到托盘)" Style="{StaticResource ToggleSwitch}" Margin="0,0,0,8"/>
                                     <CheckBox Name="CheckRunAsAdmin" Content="以管理员权限运行程序" Style="{StaticResource ToggleSwitch}" Margin="0,0,0,8" Checked="CheckRunAsAdmin_Changed" Unchecked="CheckRunAsAdmin_Changed"/>

--- a/src/OverlayManager.cs
+++ b/src/OverlayManager.cs
@@ -354,6 +354,12 @@ namespace BASpark
                 return;
             }
 
+            if (e.KeyCode == Keys.A && e.Alt && !e.Control)
+            {
+                BeginScreenshotCaptureSession();
+                return;
+            }
+
             if (e.KeyCode == Keys.Escape && _screenshotCaptureSessionActive)
             {
                 ScheduleEndScreenshotCaptureSessionDebounced();

--- a/src/Resources/Strings.en.resx
+++ b/src/Resources/Strings.en.resx
@@ -109,7 +109,7 @@
       <value>* Required for effects over elevated windows such as Task Manager.</value>
     </data>
     <data name="Basic_ScreenshotHint" xml:space="preserve">
-      <value>* (Experimental) Hides overlay briefly during screenshots or QQ screenshot hotkeys.</value>
+      <value>* (Experimental) Hides overlay briefly during screenshots, QQ screenshot hotkeys (Ctrl+Alt+A), or WeChat screenshot hotkeys (Alt+A).</value>
     </data>
     <data name="Basic_ScreenshotMode" xml:space="preserve">
       <value>Screenshot compatibility</value>

--- a/src/Resources/Strings.ja.resx
+++ b/src/Resources/Strings.ja.resx
@@ -109,7 +109,7 @@
       <value>* タスクマネージャーなどの高権限ウィンドウでエフェクトを表示する場合に必要です。</value>
     </data>
     <data name="Basic_ScreenshotHint" xml:space="preserve">
-      <value>*（実験的）スクリーンショットや QQ の既定ショートカット検出時にオーバーレイを一時非表示にします。</value>
+      <value>*（実験的）スクリーンショット、QQ の既定ショートカット (Ctrl+Alt+A)、または WeChat の既定ショートカット (Alt+A) 検出時にオーバーレイを一時非表示にします。</value>
     </data>
     <data name="Basic_ScreenshotMode" xml:space="preserve">
       <value>スクリーンショット互換</value>

--- a/src/Resources/Strings.resx
+++ b/src/Resources/Strings.resx
@@ -109,7 +109,7 @@
       <value>* 若需在任务管理器等部分高权限窗口显示特效，请勾选此项。</value>
     </data>
     <data name="Basic_ScreenshotHint" xml:space="preserve">
-      <value>* (实验性功能) 开启后截图画面将不包含特效：检测到系统截图界面或 QQ 默认截图快捷键时会短暂隐藏叠加层以便框选窗口。</value>
+      <value>* (实验性功能) 开启后截图画面将不包含特效：检测到系统截图界面、QQ 默认截图快捷键 (Ctrl+Alt+A) 或微信截图快捷键 (Alt+A) 时会短暂隐藏叠加层以便框选窗口。</value>
     </data>
     <data name="Basic_ScreenshotMode" xml:space="preserve">
       <value>截图兼容模式</value>


### PR DESCRIPTION
## 改动

- 将截图兼容模式适配了微信（微信的默认截图快捷键为 `Alt + A`）

- [feat: add WeChat screenshot hotkey (Alt+A) to screenshot compatibility mode](https://github.com/KyuharuTE/BASpark/commit/627d6a7ddc99dcf7a570d2583fdf53c83edff80f)